### PR TITLE
Add pipe lambda smoke coverage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -692,6 +692,33 @@ if(EXISTS "${CMAKE_SOURCE_DIR}/tests/smoke.sql")
         LABELS "smoke;keyword"
     )
 
+    # Pipe syntax setting and native pipe entry point smoke test
+    add_test(
+        NAME smoke_test_pipe_syntax
+        COMMAND ${CMAKE_COMMAND} -E env
+            "DUCKDB_EXTENSION_PATH=${CMAKE_BINARY_DIR}"
+            ${DUCKDB_CLI_COMMAND} -unsigned ":memory:" -c "
+                LOAD '${EXTENSION_BINARY_PATH}';
+                CREATE TABLE test_pipe AS SELECT i as id, (i % 5) + 18 as age FROM range(1, 6) as t(i);
+                SELECT COUNT(*) FROM dplyr('test_pipe %>% { . %>% select(id) %>% filter(id <= 3) }') AS t;
+                SELECT COUNT(*) FROM dplyr('test_pipe %>% { filter(., id <= 4) %>% select(., id) }') AS t;
+                SELECT COUNT(*) FROM dplyr('test_pipe %>% (. %>% select(id) %>% filter(id <= 2))') AS t;
+                SELECT COUNT(*) FROM dplyr('test_pipe |> select(id) |> filter(id <= 3)', 'native') AS t;
+                SELECT COUNT(*) FROM dplyr('test_pipe |> (\(x) x |> select(id) |> filter(id <= 3))()', 'native') AS t;
+                SELECT COUNT(*) FROM dplyr('test_pipe |> (\(x) filter(x, id <= 4) |> select(x, id))()', 'native') AS t;
+                SET dplyr_pipe_syntax = 'native';
+                SELECT dplyr_pipe_syntax();
+                SELECT COUNT(*) FROM dplyr('test_pipe |> select(id) |> filter(id <= 4)') AS t;
+                SELECT COUNT(*) FROM dplyr('test_pipe |> (\(x) x |> select(id) |> filter(id <= 2))()') AS t;
+                SET dplyr_pipe_syntax = 'magrittr';
+                SELECT COUNT(*) FROM dplyr('test_pipe %>% select(id) %>% filter(id <= 2)') AS t;
+            "
+    )
+    set_tests_properties(smoke_test_pipe_syntax PROPERTIES
+        TIMEOUT 60
+        LABELS "smoke;pipe_syntax"
+    )
+
     message(STATUS "Comprehensive smoke tests configured")
 else()
     message(WARNING "Smoke test file not found at ${CMAKE_SOURCE_DIR}/tests/smoke.sql")

--- a/tests/smoke.sql
+++ b/tests/smoke.sql
@@ -18,11 +18,15 @@ SELECT 1 AS test_column;
 -- Test 3: Verify standard SQL functions still work
 SELECT COUNT(*) AS cnt FROM (VALUES (1), (2), (3)) AS t(x);
 
+-- Test 4: Pin smoke tests to the magrittr session default
+SET dplyr_pipe_syntax = 'magrittr';
+SELECT dplyr_pipe_syntax() AS pipe_syntax;
+
 -- =============================================================================
 -- Test Data
 -- =============================================================================
 
--- Test 4: Create test data for dplyr operations
+-- Test 5: Create test data for dplyr operations
 CREATE OR REPLACE TABLE test_data AS
 SELECT
     i AS id,
@@ -40,21 +44,70 @@ SELECT COUNT(*) AS row_count FROM test_data;
 -- Table Function Entry Point
 -- =============================================================================
 
--- Test 5: Table function basic query
+-- Test 6: Table function basic query
 SELECT COUNT(*) AS cnt
 FROM dplyr('test_data %>% select(id, name) %>% filter(id <= 5)') AS t;
 
--- Test 6: Table function with aggregation
+-- Test 7: Table function with aggregation
 SELECT *
 FROM dplyr('test_data %>% group_by(category) %>% summarise(count = n(), avg_value = mean(value))') AS t;
+
+-- Test 8: Magrittr lambda RHS keeps the input table bound through `.`
+SELECT COUNT(*) AS cnt
+FROM dplyr('test_data %>% { . %>% select(id) %>% filter(id <= 3) }') AS t;
+
+-- Test 9: Magrittr lambda RHS supports dot placeholders in function arguments
+SELECT COUNT(*) AS cnt
+FROM dplyr('test_data %>% { filter(., id <= 4) %>% select(., id) }') AS t;
+
+-- Test 10: Magrittr functional sequence RHS works as a lambda shorthand
+SELECT COUNT(*) AS cnt
+FROM dplyr('test_data %>% (. %>% select(id) %>% filter(id <= 2))') AS t;
+
+-- Test 11: Magrittr RHS dot placeholder without braces remains supported
+SELECT COUNT(*) AS cnt
+FROM dplyr('test_data %>% filter(., id <= 5) %>% select(., id)') AS t;
 
 -- =============================================================================
 -- ParserExtension Entry Points
 -- =============================================================================
 
--- Test 7: Implicit pipeline statement (ParserExtension triggered by `%>%`)
+-- Test 12: Implicit pipeline statement (ParserExtension triggered by `%>%`)
 test_data %>% select(id) %>% filter(id <= 3);
 
--- Test 8: Embedded pipeline inside standard SQL
+-- Test 13: Embedded pipeline inside standard SQL
 SELECT COUNT(*) AS cnt
 FROM (| test_data %>% select(id) %>% filter(id <= 3) |) AS embedded;
+
+-- =============================================================================
+-- Pipe Syntax Configuration
+-- =============================================================================
+
+-- Test 14: Explicit native pipe syntax in the table function
+SELECT COUNT(*) AS cnt
+FROM dplyr('test_data |> select(id, name) |> filter(id <= 5)', 'native') AS t;
+
+-- Test 15: Explicit native pipe syntax supports lambda RHS
+SELECT COUNT(*) AS cnt
+FROM dplyr('test_data |> (\(x) x |> select(id) |> filter(id <= 3))()', 'native') AS t;
+
+-- Test 16: Native lambda RHS supports explicit data arguments
+SELECT COUNT(*) AS cnt
+FROM dplyr('test_data |> (\(x) filter(x, id <= 4) |> select(x, id))()', 'native') AS t;
+
+-- Test 17: Session setting enables native pipe syntax by default
+SET dplyr_pipe_syntax = 'native';
+SELECT dplyr_pipe_syntax() AS pipe_syntax;
+
+SELECT COUNT(*) AS cnt
+FROM dplyr('test_data |> select(id) |> filter(id <= 4)') AS t;
+
+SELECT COUNT(*) AS cnt
+FROM dplyr('test_data |> (\(x) x |> select(id) |> filter(id <= 2))()') AS t;
+
+-- Test 18: Switching back to magrittr keeps the original smoke path valid
+SET dplyr_pipe_syntax = 'magrittr';
+SELECT dplyr_pipe_syntax() AS pipe_syntax;
+
+SELECT COUNT(*) AS cnt
+FROM dplyr('test_data %>% select(id) %>% filter(id <= 2)') AS t;

--- a/tests/smoke_tests_README.md
+++ b/tests/smoke_tests_README.md
@@ -8,6 +8,7 @@
 - **R4-AC2**: 기본 확장 기능 및 로딩 테스트
 - **R1-AC2**: 최소 연산 집합 지원 (select, filter, mutate, arrange, group_by, summarise)
 - **R5-AC1**: `%>%` 파이프라인 기반 진입점 테스트
+- **Pipe syntax 설정**: `dplyr_pipe_syntax`, `|>` native pipe, 명시적 pipe 인자 테스트
 - **R2-AC1**: 테이블 함수 진입점 테스트
 - **R2-AC2**: 표준 SQL과의 혼용 테스트
 - **R5-AC2**: 파서 충돌/오인식 방지 테스트
@@ -41,6 +42,7 @@
 
 #### 4. Table Function Entry Point (R2-AC1)
 - `SELECT * FROM dplyr('code')` 구문 테스트
+- `SELECT * FROM dplyr('code', 'native')` 명시적 pipe syntax 테스트
 - 서브쿼리 컨텍스트에서 사용 테스트
 
 #### 5. Chained Operations (Pipeline Testing)
@@ -62,7 +64,14 @@
 #### 8. Parser Collision Avoidance (R5-AC2)
 - `%>%` 파이프라인 인식이 일반 SQL을 오인식하지 않음
 
-#### 9. Performance and Stability (R6-AC1)
+#### 9. Pipe Syntax Configuration
+- `SET dplyr_pipe_syntax = 'native'` 세션 설정 테스트
+- 명시적 pipe 인자와 세션 기본값을 통한 native pipe table function 테스트
+- `SET dplyr_pipe_syntax = 'magrittr'` 전환 후 기존 경로 유지 확인
+- magrittr 람다 RHS 변형 테스트: `{ . %>% ... }`, `{ filter(., ...) %>% ... }`, `(. %>% ...)`, RHS dot placeholder
+- native 람다 RHS 변형 테스트: `\(x)` 람다, 명시적 data 인자, 세션 기본 native pipe 설정
+
+#### 10. Performance and Stability (R6-AC1)
 - 중간 복잡도 쿼리 실행
 - 반복 실행 안정성
 - 캐싱 동작 확인


### PR DESCRIPTION
## Summary
- add smoke SQL coverage for magrittr lambda RHS variations and native pipe lambda RHS variations
- extend CTest pipe syntax smoke coverage with the same high-signal lambda paths
- document the lambda smoke matrix in the smoke test README

## Validation
- git diff --check
- cargo test lambda
- PATH=/tmp/libdplyr-smoke-cmake-check/_deps/duckdb-build:$PATH BUILD_DIR=/tmp/libdplyr-smoke-cmake-check ./tests/run_smoke_tests.sh
- PATH=/tmp/libdplyr-smoke-cmake-check/_deps/duckdb-build:$PATH ctest --test-dir /tmp/libdplyr-smoke-cmake-check -R '^smoke_' --output-on-failure --timeout 120