### PR TITLE
Prepare v0.5.0 release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -512,10 +512,10 @@ jobs:
           # DuckDB dplyr Extension ${{ github.event.release.tag_name || github.event.inputs.version }}
 
           ## 🚀 Features
-          - Complete dplyr syntax support for DuckDB
-          - Multi-platform compatibility (Linux, macOS, Windows)
-          - High-performance transpilation with caching
-          - Comprehensive error handling and debugging
+          - Native DuckDB 1.5 parser override for implicit dplyr pipeline statements
+          - Caller-context execution that preserves temporary tables and transaction state
+          - Database-global implicit pipe syntax with explicit per-call control through \`dplyr(query, mode)\`
+          - Exact-version DuckDB 1.5.0 compatibility packages and 1.5.4 primary packages, including Windows for 1.5.4
 
           ## 📦 Installation
 
@@ -536,6 +536,7 @@ jobs:
             - \`dplyr-v1.5.4-windows-x86_64.duckdb_extension\`
 
           ## 🔧 Requirements
+          - DuckDB 1.5.x is required for parser override support
           - DuckDB 1.5.4 is the primary supported current build
           - DuckDB 1.5.0 compatibility binaries are also provided
           - Load the binary that matches your exact DuckDB version
@@ -545,18 +546,23 @@ jobs:
           \`\`\`sql
           -- Load the extension
           LOAD '/path/to/dplyr-platform.duckdb_extension';
+          SET allow_parser_override_extension = 'fallback';
 
-          -- Use implicit pipeline syntax (%>%)
+          -- Use database-global magrittr syntax for implicit pipelines
+          SET GLOBAL dplyr_pipe_syntax = 'magrittr';
           mtcars %>%
                  select(mpg, cyl, hp) %>%
                  filter(mpg > 20) %>%
                  arrange(desc(hp));
+
+          -- Select native pipe syntax explicitly for one table-function call
+          SELECT * FROM dplyr('mtcars |> select(mpg, cyl)', 'native');
           \`\`\`
 
           ## ✅ Verification
-          Release artifacts are load-tested before packaging. Additional platform,
-          security, and compatibility checks are provided by the CI and security
-          workflows attached to the release branch.
+          Release artifacts are load-tested before packaging. The tagged main commit passed
+          the repository's CI and security workflows before this release, including platform,
+          parser callback safety, Windows linkage, and DuckDB 1.5.0 compatibility checks.
 
           ## 🔒 Security
           - All artifacts include SHA256 checksums
@@ -582,7 +588,7 @@ jobs:
 
           ---
 
-          **Full Changelog**: https://github.com/mrchypark/libdplyr/compare/previous-tag...${{ github.event.release.tag_name || github.event.inputs.version }}
+          **Full Changelog**: https://github.com/mrchypark/libdplyr/compare/v0.4.0...${{ github.event.release.tag_name || github.event.inputs.version }}
           EOF
 
       - name: Create or update release

--- a/.github/workflows/test-install.yml
+++ b/.github/workflows/test-install.yml
@@ -134,15 +134,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os:
-          [
-            ubuntu-20.04,
-            ubuntu-22.04,
-            macos-11,
-            macos-12,
-            windows-2019,
-            windows-2022,
-          ]
+        os: [ubuntu-22.04, macos-14, windows-2022]
 
     steps:
       - name: Checkout code

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.0] - 2026-07-14
+
+### Added
+- **DuckDB parser override**: Convert implicit dplyr pipeline statements to native DuckDB ASTs on DuckDB 1.5.x while preserving the caller's temporary tables and transaction state.
+- **Pipe syntax control**: Use the database-global `dplyr_pipe_syntax` setting for implicit pipelines and the explicit `dplyr(query, mode)` argument for per-call `magrittr` or `native` syntax.
+
+### Changed
+- **DuckDB compatibility**: Support DuckDB 1.5.0 through 1.5.4, with exact-version extension packages for the minimum compatibility and primary supported versions.
+- **Distribution**: Align release, CI, and scheduled workflows with DuckDB 1.5.0 compatibility and DuckDB 1.5.4 primary artifacts.
+
+### Fixed
+- **Extension safety**: Harden parser callbacks, generated SQL handling, option resets, and FFI error cleanup.
+- **Cross-platform CI**: Avoid linking non-exported DuckDB parser internals in Windows integration tests and qualify standard synchronization types for portable builds.
+
 ## [0.3.1] - 2026-02-02
 
 ### Changed

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@
 cmake_minimum_required(VERSION 3.15)
 
 # R8-AC1: Project version and DuckDB compatibility range
-project(dplyr VERSION 0.4.0)
+project(dplyr VERSION 0.5.0)
 
 # R8-AC1: DuckDB extension configuration
 set(DUCKDB_EXTENSION_NAME "dplyr")

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -544,7 +544,7 @@ checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
 
 [[package]]
 name = "libdplyr"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "clap",
  "colored",
@@ -563,7 +563,7 @@ dependencies = [
 
 [[package]]
 name = "libdplyr_c"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "chrono",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libdplyr"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 authors = ["libdplyr contributors"]
 description = "A Rust-based transpiler that converts R dplyr syntax to SQL queries"

--- a/USAGE_GUIDE.md
+++ b/USAGE_GUIDE.md
@@ -242,7 +242,7 @@ $ echo "select(name)" | libdplyr --json
       "input_size_bytes": 13,
       "output_size_bytes": 25
     },
-    "version": "0.4.0"
+    "version": "0.5.0"
   }
 }
 ```

--- a/build_dplyr_extension.sh
+++ b/build_dplyr_extension.sh
@@ -19,7 +19,7 @@ python3 ../../extension-ci-tools/scripts/append_extension_metadata.py \
   -o ../../dplyr.duckdb_extension \
   -n dplyr \
   -dv "${DUCKDB_VERSION}" \
-  -ev 0.4.0 \
+  -ev 0.5.0 \
   -p osx_arm64 \
   --abi-type CPP
 

--- a/community-pr/description.yml
+++ b/community-pr/description.yml
@@ -8,7 +8,7 @@
 extension:
   name: dplyr
   description: R dplyr pipeline syntax support for DuckDB - transpiles dplyr verbs to SQL
-  version: 0.4.0
+  version: 0.5.0
   language: Rust & C++
   build: cmake
   license: MIT

--- a/docs/packaging.md
+++ b/docs/packaging.md
@@ -117,7 +117,7 @@ packages/v1.0.0/
     "build_type": "Release"
   },
   "versions": {
-    "libdplyr": "0.4.0",
+    "libdplyr": "0.5.0",
     "rust": "rustc 1.75.0",
     "cmake": "cmake version 3.20.0",
     "duckdb_build_version": "1.5.4"

--- a/extension_config.cmake
+++ b/extension_config.cmake
@@ -6,9 +6,9 @@
 # R8-AC1: Extension metadata and semver policy
 set(EXTENSION_NAME "dplyr")
 set(EXTENSION_DESCRIPTION "R dplyr syntax support for DuckDB")
-set(EXTENSION_VERSION "0.4.0")
+set(EXTENSION_VERSION "0.5.0")
 set(EXTENSION_VERSION_MAJOR 0)
-set(EXTENSION_VERSION_MINOR 4)
+set(EXTENSION_VERSION_MINOR 5)
 set(EXTENSION_VERSION_PATCH 0)
 
 # Ensure DuckDB's extension metadata version is populated even when duckdb_extension_load

--- a/install.ps1
+++ b/install.ps1
@@ -11,7 +11,7 @@ param(
 $ErrorActionPreference = "Stop"
 $REPO = "mrchypark/libdplyr"
 $BINARY_NAME = "libdplyr.exe"
-$DEFAULT_VERSION = "0.4.0"
+$DEFAULT_VERSION = "0.5.0"
 
 function Write-Info { param([string]$Message); Write-Host "[INFO] $Message" -ForegroundColor Blue }
 function Write-Success { param([string]$Message); Write-Host "[SUCCESS] $Message" -ForegroundColor Green }

--- a/install.sh
+++ b/install.sh
@@ -4,7 +4,7 @@
 
 set -e
 
-VERSION="0.4.0"
+VERSION="0.5.0"
 REPO="mrchypark/libdplyr"
 BINARY_NAME="libdplyr"
 

--- a/libdplyr_c/Cargo.toml
+++ b/libdplyr_c/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libdplyr_c"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 description = "C-compatible API for libdplyr DuckDB extension"
 license = "MIT"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,7 +26,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! libdplyr = "0.4.0"
+//! libdplyr = "0.5.0"
 //! ```
 //!
 //! Basic usage:

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,5 +1,5 @@
 {
   "name": "dplyr",
-  "version-string": "0.4.0",
+  "version-string": "0.5.0",
   "dependencies": []
 }


### PR DESCRIPTION
## Summary

- bump libdplyr, C FFI, CMake, DuckDB extension, installers, and packaging metadata to 0.5.0
- add v0.5.0 CHANGELOG notes for DuckDB 1.5 parser_override support
- update generated GitHub Release notes with the exact 1.5.0/1.5.4 artifact matrix and verified provenance

## Why

The merged parser_override support is backward-compatible new functionality, so the next SemVer release is v0.5.0. Source and package metadata must be synchronized before tagging to avoid a 0.5.0 GitHub release containing 0.4.0 binaries and installers.

## Validation

- cargo test --workspace --all-features --locked: 706 passed, 0 failed, 1 existing ignored
- cargo clippy --workspace --all-targets --all-features --locked -- -D warnings
- cargo fmt --all --check
- cargo metadata --locked: libdplyr and libdplyr_c both 0.5.0
- actionlint release workflow
- shell syntax checks
- git diff --check
- independent final review: NO MATERIAL FINDINGS